### PR TITLE
feature: Runtime abstract class

### DIFF
--- a/tools/abstract/Runtime.js
+++ b/tools/abstract/Runtime.js
@@ -1,0 +1,16 @@
+class Runtime {
+  constructor() {
+    if (this.constructor === Runtime) {
+      throw new TypeError('Abstract class "Runtime" cannot be instantiated directly.');
+    }
+  }
+
+  /**
+   * Abstract method for running a code snippit
+   * @param {string} code - string of a given code snippit or command 
+   * @param {function} callback - supplied callback function that recieves result of the code snippit
+   */
+  runCode(code, callback) {
+    throw new TypeError('runCode must be implemented with a string param \'code\' and a callback function \'callback\'');
+  }
+}


### PR DESCRIPTION
https://github.com/The-Programming-Foundation/learningcodesnippets/issues/5

@ashwinkjoseph 

Chose to create an "abstract" function for `runCode` over throwing an error in the constructor is it is not present. I did this so a code string and callback function can be required. If it is prefered that the function not be defined and just check in the constructor like the example in the issue I can change it. 

I was unsure on the specification of _"Should call the callback function when the result is obtained from the runtime and shoud pass the result as an argument to the callback function."_ from the issue. This sounds like functionality that the abstract class shouldn't have. 